### PR TITLE
Add 25.11 jobsets

### DIFF
--- a/.github/workflows/gen-reports.yml
+++ b/.github/workflows/gen-reports.yml
@@ -24,6 +24,8 @@ jobs:
             jobset: trunk
           - project: nixpkgs
             jobset: nixpkgs-25.05-darwin
+          - project: nixpkgs
+            jobset: nixpkgs-25.11-darwin
 
           - project: nixpkgs
             jobset: haskell-updates
@@ -34,11 +36,15 @@ jobs:
             jobset: staging-next
           - project: nixpkgs
             jobset: staging-next-25.05
+          - project: nixpkgs
+            jobset: staging-next-25.11
 
           - project: nixos
             jobset: trunk-combined
           - project: nixos
             jobset: release-25.05
+          - project: nixos
+            jobset: release-25.11
 
     name: ${{ matrix.project }}:${{ matrix.jobset }}
     uses: ./.github/workflows/gen-report.yml


### PR DESCRIPTION
`nixos:release-25.11` and `nixpkgs:nixpkgs-25.11-darwin` have evaluations already, `nixpkgs:staging-next-25.11` not yet. But from what I can tell, this is handled gracefully in the `gen-report` workflow anyway.

25.11 release is scheduled for 2025-11-30: https://github.com/NixOS/nixpkgs/issues/443568.

Feel free to merge this (or not) whenever you see fit. :)