### PR TITLE
Add 26.05 jobsets, remove 25.05 jobsets

### DIFF
--- a/.github/workflows/gen-reports.yml
+++ b/.github/workflows/gen-reports.yml
@@ -26,6 +26,8 @@ jobs:
             jobset: nixpkgs-25.05-darwin
           - project: nixpkgs
             jobset: nixpkgs-25.11-darwin
+          - project: nixpkgs
+            jobset: nixpkgs-26.05-darwin
 
           - project: nixpkgs
             jobset: haskell-updates
@@ -38,6 +40,8 @@ jobs:
             jobset: staging-next-25.05
           - project: nixpkgs
             jobset: staging-next-25.11
+          - project: nixpkgs
+            jobset: staging-next-26.05
 
           - project: nixos
             jobset: unstable
@@ -45,6 +49,8 @@ jobs:
             jobset: release-25.05
           - project: nixos
             jobset: release-25.11
+          - project: nixos
+            jobset: release-26.05
 
     name: ${{ matrix.project }}:${{ matrix.jobset }}
     uses: ./.github/workflows/gen-report.yml

--- a/.github/workflows/gen-reports.yml
+++ b/.github/workflows/gen-reports.yml
@@ -23,8 +23,6 @@ jobs:
           - project: nixpkgs
             jobset: unstable
           - project: nixpkgs
-            jobset: nixpkgs-25.05-darwin
-          - project: nixpkgs
             jobset: nixpkgs-25.11-darwin
           - project: nixpkgs
             jobset: nixpkgs-26.05-darwin
@@ -37,16 +35,12 @@ jobs:
           - project: nixpkgs
             jobset: staging-next
           - project: nixpkgs
-            jobset: staging-next-25.05
-          - project: nixpkgs
             jobset: staging-next-25.11
           - project: nixpkgs
             jobset: staging-next-26.05
 
           - project: nixos
             jobset: unstable
-          - project: nixos
-            jobset: release-25.05
           - project: nixos
             jobset: release-25.11
           - project: nixos


### PR DESCRIPTION
All relevant 26.05 jobsets already have evaluations:

- https://hydra.nixos.org/jobset/nixpkgs/nixpkgs-26.05-darwin
- https://hydra.nixos.org/jobset/nixpkgs/staging-next-26.05
- https://hydra.nixos.org/jobset/nixos/release-26.05

26.05 release is scheduled for 2026-05-30: https://github.com/NixOS/nixpkgs/issues/503391

Feel free to merge this whenever you see fit. :)